### PR TITLE
Update dead link to fake6502.c to use Internet Archive

### DIFF
--- a/app/views/Tools/emu.html
+++ b/app/views/Tools/emu.html
@@ -100,7 +100,7 @@
         </li>
 
         <li>
-          <a href="http://rubbermallet.org/fake6502.c">fake6502</a> - Mike Chambers
+          <a href="https://web.archive.org/web/20260430030358/http://rubbermallet.org/fake6502.c">fake6502</a> - Mike Chambers
           has written a cycle-accurate 6502 emulator in C.
         </li>
 


### PR DESCRIPTION
As https://rubbermallet.org is currently down and the link returns a 404, I've replaced the link to fake6502.c with the most recent snapshot on the Internet Archive: April 30, 2026. This should help people looking for fake6502.c find the version referenced on 6502.org.